### PR TITLE
Our project link was not working

### DIFF
--- a/category/glug/index.html
+++ b/category/glug/index.html
@@ -244,7 +244,7 @@
                 <li><a target="blank" href="https://github.com/glugmv">GitHub</a></li>
                 <li><a target="blank" href="https://developers.google.com/speed/pagespeed/insights/?url=blog.glugmvit.com">Page Speed Test</a></li>
                 <li><a target="blank" href="/contact/">Partner with Us</a></li>
-                <li><a target="blank" href="https://github.com/glugmv">Our Projects</a></li>
+                <li><a target="blank" href="https://github.com/glugmvit">Our Projects</a></li>
                 </ul>
                 </div>
                 </div>


### PR DESCRIPTION
Our Project link in the footer was not working properly it was pointing to the error page on Github '404 Page Not Found'.
Corrected it by placing a new link replacing the older one.
Earlier it was https://github.com/glugmv which is an invalid link.
Changed it to https://github.com/glugmvit which I guess is pointing to the correct place.